### PR TITLE
Fix 5: #116 (Maintainability) Removing Redundant Commented Code for Better Maintainability

### DIFF
--- a/robocode.api/src/main/java/net/sf/robocode/serialization/RbSerializer.java
+++ b/robocode.api/src/main/java/net/sf/robocode/serialization/RbSerializer.java
@@ -225,9 +225,6 @@ public final class RbSerializer {
 		} else {
 			buffer.put(TERMINATOR_TYPE);
 		}
-		// FOR-DEBUG if (expect != buffer.position()) {
-		// FOR-DEBUG 	throw new Error("Bad size");
-		// FOR-DEBUG }
 	}
 
 	public void serialize(ByteBuffer buffer, String data) {


### PR DESCRIPTION
Removed unnecessary commented-out code (java:S125) to improve readability and maintainability. Commented code adds clutter and quickly becomes outdated, so it’s best managed through version control.