### PR TITLE
Casted the variables to Double to avoid any future calculation errors

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -26,5 +26,10 @@
       <option name="name" value="MavenLocal" />
       <option name="url" value="file:/$MAVEN_REPOSITORY$/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:/$PROJECT_DIR$/../../../Maheen%20Atiq/.m2/repository/" />
+    </remote-repository>
   </component>
 </project>

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
@@ -679,11 +679,11 @@ public final class RobotPeer implements IRobotPeerBattle, IRobotPeer {
 		if (!valid) {
 			final Random random = RandomFactory.getRandom();
 
-			double maxWidth = battleRules.getBattlefieldWidth() - RobotPeer.WIDTH;
-			double maxHeight = battleRules.getBattlefieldHeight() - RobotPeer.HEIGHT;
+			double maxWidth = (double) battleRules.getBattlefieldWidth() - RobotPeer.WIDTH;
+			double maxHeight = (double) battleRules.getBattlefieldHeight() - RobotPeer.HEIGHT;
 
-			double halfRobotWidth = RobotPeer.WIDTH / 2;
-			double halfRobotHeight = RobotPeer.HEIGHT / 2;
+			double halfRobotWidth = (double) RobotPeer.WIDTH / 2;
+			double halfRobotHeight = (double) RobotPeer.HEIGHT / 2;
 
 			int sentryBorderSize = battle.getBattleRules().getSentryBorderSize();
 			int sentryBorderMoveWidth = sentryBorderSize - RobotPeer.WIDTH;


### PR DESCRIPTION
The warning suggests that you cast one operand of the subtraction operation to double to ensure correct floating-point calculations. The variables listed below might be ints, which can cause unexpected rounding errors in some cases. So, it is better to implicitly convert them into doubles on lines 682, 683, 685, and 686.
●	WIDTH
●	HEIGHT
