### PR TITLE
Fix Path Traversal vulnerability in JarExtractor.extractFile method

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -64,23 +64,32 @@ public class JarExtractor {
 		}
 	}
 
-	public static void extractFile(File dest, JarInputStream jarIS, JarEntry entry) throws IOException {
-		File out = new File(dest, entry.getName());
-		File parentDirectory = new File(out.getParent());
+	public static void extractFile(File destDir, JarInputStream jarIS, JarEntry entry) throws IOException {
+		File canonicalDestDir = destDir.getCanonicalFile();
 
+		File outFile = new File(destDir, entry.getName());
+		File canonicalOutFile = outFile.getCanonicalFile();
+
+		if (!canonicalOutFile.getPath().startsWith(canonicalDestDir.getPath() + File.separator)) {
+			Logger.logError("Entry is outside the target dir: " + entry.getName());
+			return;
+		}
+
+		File parentDirectory = new File(canonicalOutFile.getParent());
 		if (!parentDirectory.exists() && !parentDirectory.mkdirs()) {
 			Logger.logError("Cannot create dir: " + parentDirectory);
+			return;
 		}
+
 		FileOutputStream fos = null;
 		BufferedOutputStream bos = null;
 		byte[] buf = new byte[2048];
 
 		try {
-			fos = new FileOutputStream(out);
+			fos = new FileOutputStream(canonicalOutFile);
 			bos = new BufferedOutputStream(fos);
 
 			int num;
-
 			while ((num = jarIS.read(buf, 0, 2048)) != -1) {
 				bos.write(buf, 0, num);
 			}
@@ -89,4 +98,5 @@ public class JarExtractor {
 			FileUtil.cleanupStream(fos);
 		}
 	}
+
 }


### PR DESCRIPTION
FIx issue [#52](https://github.com/SOEN6431Winter2025/robocodeW25/issues/52)
- Added path sanitization to prevent extraction of files outside the target directory.
- Implemented canonical path resolution and validation to ensure files are written only within the intended destination directory.
- Skipped extraction of entries with invalid paths and logged appropriate errors.

This change mitigates the risk of arbitrary file writes due to Path Traversal attacks.