### PR TITLE
Fix#63: Ensure lastResults is populated before dumping battle results

### DIFF
--- a/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/BattlesRunner.java
+++ b/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/BattlesRunner.java
@@ -102,8 +102,23 @@ public class BattlesRunner {
 
 					lastResults = null;
 					engine.runBattle(specification, true);
+
+					// Wait until lastResults is set, with timeout
+					int waitTime = 0;
+					while (lastResults == null && waitTime < 3000) {
+						try {
+							Thread.sleep(100);
+							waitTime += 100;
+						} catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
+							break;
+						}
+					}
+
 					if (lastResults != null && lastResults.length > 1) {
 						dumpResults(outtxt, lastResults, rumbleBattle, melee);
+					} else {
+						System.err.println("Warning: Battle did not produce valid results.");
 					}
 				}
 			} else {


### PR DESCRIPTION
The battle results were not being dumped because lastResults was null when checked immediately after runBattle(). This occurred due to its asynchronous assignment via the onBattleCompleted() callback.

Added a wait loop after runBattle() to allow time for lastResults to populate before processing. This ensures results are reliably captured and dumpResults() executes as expected.